### PR TITLE
fix: handle dict data matching errors and word segmentation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-ime",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-ime",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "dawg-lookup": "^2.2.1",

--- a/src/engine/dict.ts
+++ b/src/engine/dict.ts
@@ -4,24 +4,37 @@ import dictTxt from '../data/dict.txt?raw'
 type Dict = Record<string, string>
 
 export const dict: Dict = (() => {
-  const reg = /([a-z]+)\s+(\S*)[$|\n]/g
+  // 修复正则表达式，正确匹配拼音和对应的汉字
+  const reg = /([a-z]+)\s+([^\n]*)/g
   const dictObj: Record<string, string> = {}
   let res = reg.exec(dictTxt)
   while (res && res.length >= 3) {
-    dictObj[res[1]] = res[2]
+    // 去除内容末尾的换行符并存储
+    dictObj[res[1]] = res[2].trim()
     res = reg.exec(dictTxt)
   }
   return dictObj
 })()
 
 export function getWordsFormDict(pinyin: string): DictWord[] {
-  const reg = /(\D+)(\d+)/g
-  const content = dict[pinyin]
+  // 规范化输入的拼音：移除单引号，因为词库中不包含引号，然后转为小写
+  const normalizedPinyin = pinyin
+    .replace(/'/g, '') // 移除所有单引号
+    .toLowerCase(); // 统一转小写
+  
+  // 检查规范化后的拼音是否为空
+  if (!normalizedPinyin.trim()) {
+    return [];
+  }
+  
+  const content = dict[normalizedPinyin]
   if (!content) {
     return []
   }
-  let res = reg.exec(content)
+  
+  const reg = /(\D+)(\d+)/g
   const list: DictWord[] = []
+  let res = reg.exec(content)
   while (res && res.length >= 3) {
     list.push({
       w: res[1],

--- a/src/engine/dict.ts
+++ b/src/engine/dict.ts
@@ -20,18 +20,18 @@ export function getWordsFormDict(pinyin: string): DictWord[] {
   // 规范化输入的拼音：移除单引号，因为词库中不包含引号，然后转为小写
   const normalizedPinyin = pinyin
     .replace(/'/g, '') // 移除所有单引号
-    .toLowerCase(); // 统一转小写
-  
+    .toLowerCase() // 统一转小写
+
   // 检查规范化后的拼音是否为空
   if (!normalizedPinyin.trim()) {
-    return [];
+    return []
   }
-  
+
   const content = dict[normalizedPinyin]
   if (!content) {
     return []
   }
-  
+
   const reg = /(\D+)(\d+)/g
   const list: DictWord[] = []
   let res = reg.exec(content)

--- a/src/engine/pinyin.ts
+++ b/src/engine/pinyin.ts
@@ -2,7 +2,7 @@ import type { PinyinSyllables } from '../types'
 import pinyinText from '../data/pinyin.txt?raw'
 import { damerauLevenshteinDistanceCorrector } from './corrector'
 
-export const pinyinSet = new Set<string>(pinyinText.split('\n'))
+export const pinyinSet = new Set<string>(pinyinText.split(/\r?\n/))
 
 export function appendSyllables(syllables: PinyinSyllables[], appended: PinyinSyllables[]) {
   const len = syllables.length


### PR DESCRIPTION
The latest version v1.2.3 has dictionary data matching errors and word segmentation errors in the windows system, as shown in the following figure:
<img width="807" height="325" alt="image" src="https://github.com/user-attachments/assets/ac556204-fa76-4a78-adb5-b0e3b2ccd38e" />

The repaired effect is as shown in the following picture:
<img width="858" height="324" alt="image" src="https://github.com/user-attachments/assets/42e6de89-6095-4486-bf31-3b2220330758" />
